### PR TITLE
Launch process in terminal emulator if required

### DIFF
--- a/src/common/desktop_entry.rs
+++ b/src/common/desktop_entry.rs
@@ -70,6 +70,18 @@ impl DesktopEntry {
             })
             .collect::<Vec<_>>();
 
+        // If the entry expects a terminal (emulator), but this process is not running in one, we
+        // launch a new one.
+        if self.term && !atty::is(atty::Stream::Stdout) {
+            let config = crate::config::Config::load()?;
+            let terminal_emulator_args =
+                shlex::split(&config.terminal_emulator).unwrap();
+            split = terminal_emulator_args
+                .into_iter()
+                .chain(split.into_iter())
+                .collect();
+        }
+
         Ok((split.remove(0), split))
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 pub struct Config {
     pub enable_selector: bool,
     pub selector: String,
+    pub terminal_emulator: String,
 }
 
 impl Default for Config {
@@ -12,6 +13,7 @@ impl Default for Config {
         Config {
             enable_selector: false,
             selector: "rofi -dmenu -p 'Open With: '".to_owned(),
+            terminal_emulator: "xterm -e".to_owned(),
         }
     }
 }


### PR DESCRIPTION
If a desktop entry requires a terminal, but the current process does not
run in one, the process would previously run invisibly in the
background. Now we instead start the process in a newly launched
terminal in that case. This is especially useful when (for example)
opening text files downloaded in a browser using the system open dialog.

For now the terminal emulator to be used is specified in the
configuration file. When/if there is a standard way to select the
terminal emulator, it is conceivable to use that method instead or if no
config item is present (see
https://gitlab.freedesktop.org/xdg/xdg-utils/-/issues/84).