### PR TITLE
Fix crash on read-only mimeapps

### DIFF
--- a/src/apps/user.rs
+++ b/src/apps/user.rs
@@ -113,9 +113,10 @@ impl MimeApps {
     pub fn read() -> Result<Self> {
         let raw_conf = {
             let mut buf = String::new();
+            let exists = std::path::Path::new(&Self::path()?).exists();
             std::fs::OpenOptions::new()
-                .write(true)
-                .create(true)
+                .write(!exists)
+                .create(!exists)
                 .read(true)
                 .open(Self::path()?)?
                 .read_to_string(&mut buf)?;


### PR DESCRIPTION
Currently handlr is not usable (i.e. it crashes) if mimeapps.list is read-only e.g. because it is managed by something like [home-manager](https://github.com/nix-community/home-manager). Write permissions are not necessary when reading the file.

I have tested this patch and `handlr list` and `handlr open` are working just fine.