### PR TITLE
Add bash completion script

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ handlr launch x-scheme-handler/https -- https://google.ca
 - Far easier to use with simple commands like `get`, `set`, `list`
 - Can operate on extensions, **no need to look up or remember mime types**
   - useful for common tasks like setting a handler for png/docx/etc files
-- Superb autocomplete (currently just fish), including mimes, extensions, and `.desktop` files
+- Superb autocomplete (currently fish, zsh and bash), including mimes, extensions, and `.desktop` files
 - Optional json output for scripting
 - Properly supports `Terminal=true` entries
 
@@ -109,7 +109,7 @@ cargo install handlr
 ### Binaries
 
 1. Download the latest [release binary](https://github.com/chmln/handlr/releases) and put it somewhere in `$PATH`
-2. Download completions:
+2. Download completions for fish:
 ```sh
 curl https://raw.githubusercontent.com/chmln/handlr/master/completions/handlr.fish --create-dirs -o ~/.config/fish/completions/handlr.fish
 ```

--- a/completions/handlr
+++ b/completions/handlr
@@ -1,0 +1,34 @@
+_handlr()
+{
+    local cur prev words cword
+    _init_completion || return
+
+    if ((cword == 1)); then
+        COMPREPLY=($(compgen -W 'get help launch list open set unset' -- "$cur"))
+    else
+        case ${words[1]} in
+            set | add)
+                if ((cword == 2)); then
+                    COMPREPLY=($(compgen -W '$(handlr autocomplete -m)' -- "$cur"))
+                elif ((cword == 3)); then
+                    COMPREPLY=($(compgen -W '$(handlr autocomplete -d | cut -f1)' -- "$cur"))
+                fi
+                ;;
+            open)
+                _filedir
+                ;;
+            unset | get)
+                COMPREPLY=($(compgen -W '$(handlr autocomplete -m)' -- "$cur"))
+                ;;
+            launch)
+                if ((cword == 2)); then
+                    COMPREPLY=($(compgen -W '$(handlr autocomplete -m)' -- "$cur"))
+                else
+                    _filedir
+                fi
+                ;;
+        esac
+    fi
+}
+
+complete -F _handlr handlr


### PR DESCRIPTION
We need to remember to ask the maintainers of https://aur.archlinux.org/packages/handlr/ and https://aur.archlinux.org/packages/handlr-bin/ to add an install hook on the next release.