### PR TITLE
Update installation instructions for Arch Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,13 +91,13 @@ handlr add x-scheme-handler/https firefox-developer-edition.desktop
 ### Arch Linux
 
 ```sh
-yay -S handlr-bin
+pacman -S handlr
 ```
 
 Optionally you can also install `xdg-utils-handlr` to replace `xdg-open`:
 
 ```sh
-yay -S xdg-utils-handlr
+paru -S xdg-utils-handlr
 ```
 
 ### Rust/Cargo


### PR DESCRIPTION
`handlr` is moved to the community repository which means it now can be installed with `pacman`: https://archlinux.org/packages/community/x86_64/handlr/

Also, `paru` is an AUR helper written in Rust so there isn't harm in suggesting it instead of `yay` :)

