### PR TITLE
add show command

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -17,6 +17,12 @@ pub enum Cmd {
         paths: Vec<UserPath>,
     },
 
+    /// Show command to be executed by "open" command
+    Show {
+        #[clap(required = true)]
+        paths: Vec<UserPath>,
+    },
+
     /// Set the default handler for mime/extension
     Set {
         mime: MimeOrExtension,


### PR DESCRIPTION
This little commit adds `show` command to simplify debugging user configs. Sometimes it is pretty helpful to see what and with what arguments gets executed.